### PR TITLE
added "classSource" to classPath so that the plugin works properly if an entity is in src/test/java

### DIFF
--- a/src/main/java/org/avaje/ebean/typequery/maven/MavenEnhanceTask.java
+++ b/src/main/java/org/avaje/ebean/typequery/maven/MavenEnhanceTask.java
@@ -103,7 +103,7 @@ public class MavenEnhanceTask extends AbstractMojo {
   private URL[] buildClassPath() {
 
     try {
-      List<URL> urls = new ArrayList<>(compileClasspathElements.size());
+      List<URL> urls = new ArrayList<>(compileClasspathElements.size()+1);
 
       Log log = getLog();
 
@@ -113,7 +113,11 @@ public class MavenEnhanceTask extends AbstractMojo {
         }
         urls.add(new File(element).toURI().toURL());
       }
-
+      // Add also classSource to classPath
+      URL classSourceUrl =new File(classSource).toURI().toURL();
+      if (!urls.contains(classSourceUrl)) {
+    	  urls.add(classSourceUrl);
+      }
       return urls.toArray(new URL[urls.size()]);
 
     } catch (MalformedURLException e) {


### PR DESCRIPTION
This fixes the problem described here: https://groups.google.com/forum/#!topic/ebean/GLq2Jvmb6no
